### PR TITLE
Updated to use both vite and node properly, as well as initial api route to /products configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist-ssr
 *.local
 .eslintrc.js
 package-lock.json
+config.js

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # Project Catwalk
-Hackreactor FEC Project
+## Hackreactor Frontend Capstone Project
 
-## Using Vite to run/compile app
+ Using Vite to transpile web app<br >
+ Express server to run authentication and direct routes to Atelier API<br >
+ React components to create dynamic web app<br >
+
+## To run current devolopment:
+npm run devVite <br >
+npm run devNode <br >
+
+Vite server is at http://localhost:3000<br >
+Node server is at http://localhost:3001<br >
+
+Create a config.js using the format of config.example.js with your github api token in the root directory<br >
 
 ## Widget Owners:
-Details : Lenora
-Related : Cora
-Questions : Matt
-Reviews : Jesus
+Details : Lenora<br >
+Related : Cora<br >
+Questions : Matt<br >
+Reviews : Jesus<br >

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,3 @@
+module.exports = {
+  TOKEN: 'FILL_IN_TOKEN'
+};

--- a/helpers/atelier.js
+++ b/helpers/atelier.js
@@ -1,0 +1,27 @@
+const axios = require('axios');
+const config = require('../config.js');
+
+const server = 'https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp';
+
+let getAtetlier = (endpoint, callback) => {
+
+  let options = {
+    method: 'GET',
+    url: server + endpoint,
+    headers: {
+      'User-Agent': 'request',
+      'Authorization': `${config.TOKEN}`,
+    }
+  };
+
+  axios(options)
+    .then ( (result) => {
+      callback(null, result.data);
+    })
+    .catch( (err) => {
+      callback(err, null);
+    });
+};
+
+
+module.exports.getAtetlier = getAtetlier;

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "devBuild": "vite build -w",
     "dev": "concurrently \"npm run devNode\" \"npm run devBuild\"",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^0.21.4",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"

--- a/server/server.js
+++ b/server/server.js
@@ -1,16 +1,48 @@
 const express = require('express');
+const cors = require('cors');
 const path = require('path');
-const { createServer: createViteServer } = require('vite');
+const axios = require('axios');
+const atelier = require('../helpers/atelier.js');
 const PORT = 3001;
+
+
 
 const app = express();
 
 app.use(express.static(path.join(__dirname, '..', 'dist')));
 app.use(express.json());
+app.use(cors());
 
 app.get('/', (req, res) => {
   res.send('Hello from the server!');
 });
+
+app.get('/products', (req, res) => {
+  console.log(req.url);
+  atelier.getAtetlier(req.url, (err, productData) => {
+    if (err) {
+      console.log('get /products: ', err);
+      res.status(404).send(err);
+    } else {
+      console.log('product get: ', productData);
+      res.status(200).send(productData);
+    }
+  });
+});
+
+app.get('/products/:product_id', (req, res) => {
+  console.log(req.url);
+  atelier.getAtetlier(req.url, (err, productData) => {
+    if (err) {
+      console.log(`get ${req.url}: ${err}`);
+      res.status(404).send(`Failed to find product id: ${req.params.product_id}`);
+    } else {
+      console.log('product get: ', productData);
+      res.status(200).send(productData);
+    }
+  });
+});
+
 
 app.listen(PORT, () => {
   console.log(`Server listening at localhost:${PORT}!`);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,9 @@ import Details from './Details/Details.jsx';
 import Questions from './Questions/Questions.jsx';
 import Reviews from './Reviews/Reviews.jsx';
 import Related from './Related/Related.jsx';
+import axios from 'axios';
+
+let server = 'http://localhost:3001';
 
 class App extends React.Component {
   constructor(props) {
@@ -11,6 +14,22 @@ class App extends React.Component {
     this.state = {
 
     };
+    this.update = this.update.bind(this);
+  }
+
+  update() {
+    axios.get(server + '/products')
+      .then( (result) => {
+        console.log('axios success', result);
+      })
+      .catch( (err) => {
+        console.log('axios err', err);
+      });
+  }
+
+  componentDidMount() {
+    console.log('mounted');
+    this.update();
   }
 
   render() {


### PR DESCRIPTION
@Lenaciousd @matthewtboyle @JGon26 I've set up the server to process requests from vite -> node -> atelier api and return back down the path. There are more routes to configure still for the different api calls we will need for each of our widgets, but have the framework built out and confirmed works. You can see this by running the updated run commands `npm run devVite` and `npm run devNode` and visiting localhost:3000 and observing the console. It will report back a get request to the atelier api at /products when the component mounts at the moment. You can also see this behavior in postman. Please review the functionality works on your end after pulling down. Thanks!

https://trello.com/c/TbDHJNHY
https://trello.com/c/CaLtg0ER