### PR TITLE
Added Working Carousel for Related Items

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import { ContextObj } from './ContextObj';
 
 const App = () => {
 
-  const [productId, setProductId] = useState(40390);
+  const [productId, setProductId] = useState(40350);
   const [productInfo, setProductInfo] = useState({});
   const [ratingAvg, setRatingAvg] = useState(0);
   const [reviewsTotal, setReviewsTotal] = useState(0);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import { ContextObj } from './ContextObj';
 
 const App = () => {
 
-  const [productId, setProductId] = useState(40350);
+  const [productId, setProductId] = useState(40390);
   const [productInfo, setProductInfo] = useState({});
   const [ratingAvg, setRatingAvg] = useState(0);
   const [reviewsTotal, setReviewsTotal] = useState(0);
@@ -32,7 +32,7 @@ const App = () => {
 
   return (
     <div>
-      {isLoaded && <ContextObj.Provider value={{ productId, productInfo, ratingAvg, reviewsTotal }}>
+      {isLoaded && <ContextObj.Provider value={{ productId, setProductId, productInfo, ratingAvg, reviewsTotal }}>
         {/* <Details /> */}
         <Related />
         <Questions />

--- a/src/Components/Related/Carousel.jsx
+++ b/src/Components/Related/Carousel.jsx
@@ -1,14 +1,42 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { ContextObj } from '../../ContextObj.jsx';
+import ProductCard from './ProductCard';
 import './styles.css';
 
 
-const App = () => {
+const Carousel = (props) => {
+  const {children} = props;
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [carouselLength, setCarouselLength] = useState(children.length);
 
+  useEffect(() => {
+    setCarouselLength(children.length);
+  }, [children]);
+
+  const next = () => {
+    if (currentIndex < (carouselLength - 1)) {
+      setCurrentIndex(prevState => prevState + 1 );
+    }
+  };
+
+  const prev = () => {
+    if (currentIndex > 0) {
+      setCurrentIndex(prevState => prevState - 1 );
+    }
+  };
 
   return (
-    <div className='carousel'>
-
+    <div className='carousel-container'>
+      <div className='carousel-wrapper'>
+        {currentIndex > 0 && <button className='left-arrow' onClick={prev}>&lt;</button>}
+        <div className='carousel-content-wrapper'>
+          <div className='carousel-content'
+            style={{ transform: `translateX(-${currentIndex * 100}%)` }}>
+            {children}
+          </div>
+        </div>
+        {currentIndex < (carouselLength - 1) && <button className='right-arrow' onClick={next}>&gt;</button>}
+      </div>
     </div>
   );
 

--- a/src/Components/Related/Carousel.jsx
+++ b/src/Components/Related/Carousel.jsx
@@ -5,7 +5,7 @@ import './styles.css';
 
 
 const Carousel = (props) => {
-  const {children} = props;
+  const {children, show} = props;
   const [currentIndex, setCurrentIndex] = useState(0);
   const [carouselLength, setCarouselLength] = useState(children.length);
 
@@ -14,7 +14,7 @@ const Carousel = (props) => {
   }, [children]);
 
   const next = () => {
-    if (currentIndex < (carouselLength - 1)) {
+    if (currentIndex < (carouselLength - show)) {
       setCurrentIndex(prevState => prevState + 1 );
     }
   };
@@ -30,12 +30,12 @@ const Carousel = (props) => {
       <div className='carousel-wrapper'>
         {currentIndex > 0 && <button className='left-arrow' onClick={prev}>&lt;</button>}
         <div className='carousel-content-wrapper'>
-          <div className='carousel-content'
-            style={{ transform: `translateX(-${currentIndex * 100}%)` }}>
+          <div className={`carousel-content show-${show}`}
+            style={{ transform: `translateX(-${currentIndex * (100 / show)}%)` }}>
             {children}
           </div>
         </div>
-        {currentIndex < (carouselLength - 1) && <button className='right-arrow' onClick={next}>&gt;</button>}
+        {currentIndex < (carouselLength - show) && <button className='right-arrow' onClick={next}>&gt;</button>}
       </div>
     </div>
   );

--- a/src/Components/Related/Carousel.jsx
+++ b/src/Components/Related/Carousel.jsx
@@ -1,0 +1,17 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { ContextObj } from '../../ContextObj.jsx';
+import './styles.css';
+
+
+const App = () => {
+
+
+  return (
+    <div className='carousel'>
+
+    </div>
+  );
+
+};
+
+export default Carousel;

--- a/src/Components/Related/Outfits.jsx
+++ b/src/Components/Related/Outfits.jsx
@@ -4,13 +4,13 @@ import ProductCard from './ProductCard';
 import './styles.css';
 import { getServer, grabReviewScore, formatDate } from '../../helpers';
 
-const Outfits = () => {
+const Outfits = (props) => {
 
   const { productId } = useContext(ContextObj);
 
   return (
     <div className='outfits'>
-      <ProductCard item={productId} />
+      <ProductCard cardId={productId} />
     </div>
   );
 };

--- a/src/Components/Related/Outfits.jsx
+++ b/src/Components/Related/Outfits.jsx
@@ -7,10 +7,18 @@ import { getServer, grabReviewScore, formatDate } from '../../helpers';
 const Outfits = (props) => {
 
   const { productId } = useContext(ContextObj);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    setIsLoaded(true);
+  }, [productId]);
 
   return (
-    <div className='outfits'>
-      <ProductCard cardId={productId} />
+    <div>
+      {isLoaded &&
+        <div className='outfits'>
+          <ProductCard cardId={productId} />
+        </div>}
     </div>
   );
 };

--- a/src/Components/Related/ProductCard.jsx
+++ b/src/Components/Related/ProductCard.jsx
@@ -3,31 +3,50 @@ import { ContextObj } from '../../ContextObj.jsx';
 import './styles.css';
 import { getServer, grabReviewScore, formatDate } from '../../helpers';
 
-const ProductCard = (props) => {
+const ProductCard = ({cardId}) => {
 
-  const { productId } = useContext(ContextObj);
-  const [carouselItem, setCarouselItem] = useState({});
-  const [carouselStyle, setCarouselStyle] = useState({results: [{photos: [{'thumbnail_url': null}]}]});
+  const { productId, ratingAvg } = useContext(ContextObj);
+
+  const [name, setName] = useState();
+  const [category, setCategory] = useState();
+  const [thumbnail, setThumbnail] = useState();
+  const [originalPrice, setOriginalPrice] = useState();
+  const [salePrice, setSalePrice] = useState();
+  const [rating, setRating] = useState();
+  const [isLoaded, setIsLoaded] = useState(true);
+
 
   useEffect(() => {
-    if (productId) {
-      getServer(`/products/${props.item}/`)
-        .then( (result) => {
-          setCarouselItem(result);
-        });
-      getServer(`/products/${props.item}/styles`)
-        .then( (result) => {
-          setCarouselStyle(result);
-        });
-    }
-  }, [productId]);
+    Promise.all([
+      getServer(`/products/${cardId}/`),
+      getServer(`/products/${cardId}/styles`),
+      getServer(`/reviews/meta/?product_id=${cardId}`)
+    ])
+      .then(([product, styles, reviewMeta]) => {
+        setName(product.name);
+        setCategory(product.category);
+        setThumbnail(styles.results[0].photos[0].thumbnail_url);
+        setOriginalPrice(styles.results[0].original_price);
+        setSalePrice(styles.results[0].sale_price);
+        setRating(grabReviewScore(reviewMeta.ratings)[0]);
+        setIsLoaded(true);
+      })
+      .catch( (err) => {
+        console.log('ProductCard Promise: ', err);
+      });
+  }, []);
 
   return (
-    <div className='productCard'>Product Card {props.item}
-      <div><img className='relatedPhoto' src={carouselStyle['results'][0]['photos'][0].thumbnail_url} /></div>
-      <div>{carouselItem.name}</div>
-      <div>{carouselItem.default_price}</div>
-
+    <div className='productCard'>
+      {isLoaded &&
+        <div>
+          <div><img className='relatedPhoto' src={thumbnail} /></div>
+          <div>{category}</div>
+          <div>{name}</div>
+          <div>${originalPrice}</div>
+          <div>{rating}</div>
+          <div></div>
+        </div>}
     </div>
   );
 

--- a/src/Components/Related/ProductCard.jsx
+++ b/src/Components/Related/ProductCard.jsx
@@ -37,10 +37,10 @@ const ProductCard = ({cardId}) => {
   }, []);
 
   return (
-    <div className='productCard'>
+    <div>
       {isLoaded &&
-        <div>
-          <div><img className='relatedPhoto' src={thumbnail} /></div>
+        <div className='productCard'>
+          <div className='card-wrapper'><img className='relatedPhoto' src={thumbnail} /></div>
           <div>{category}</div>
           <div>{name}</div>
           <div>${originalPrice}</div>

--- a/src/Components/Related/ProductCard.jsx
+++ b/src/Components/Related/ProductCard.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { ContextObj } from '../../ContextObj.jsx';
 import './styles.css';
-import { getServer, grabReviewScore, formatDate } from '../../helpers';
+import { getServer, grabReviewScore } from '../../helpers';
 
 const ProductCard = ({cardId}) => {
 
-  const { productId, ratingAvg } = useContext(ContextObj);
+  const { productId, setProductId, ratingAvg } = useContext(ContextObj);
 
   const [name, setName] = useState();
   const [category, setCategory] = useState();
@@ -39,7 +39,7 @@ const ProductCard = ({cardId}) => {
   return (
     <div>
       {isLoaded &&
-        <div className='productCard'>
+        <div className='productCard' onClick={() => setProductId(cardId)}>
           <div className='card-wrapper'><img className='relatedPhoto' src={thumbnail} /></div>
           <div>{category}</div>
           <div>{name}</div>

--- a/src/Components/Related/Related.jsx
+++ b/src/Components/Related/Related.jsx
@@ -25,7 +25,7 @@ const Related = (props) => {
   return (
     <div className='relatedCarousel'>
       {(relatedItems.length > 0) && relatedItems.map( (item, index) => {
-        return <ProductCard key={index} item={item}/>;
+        return <ProductCard key={item} cardId={item}/>;
       })}
       <Outfits />
     </div>

--- a/src/Components/Related/Related.jsx
+++ b/src/Components/Related/Related.jsx
@@ -28,7 +28,7 @@ const Related = (props) => {
   return (
     <div className='related'>
       {isLoaded && <div>
-        <Carousel>
+        <Carousel show={(relatedItems.length > 4) ? 4 : relatedItems.length}>
           {(relatedItems.length > 0) && relatedItems.map( (item, index) => {
             return <ProductCard key={item} cardId={item}/>;
           })}

--- a/src/Components/Related/Related.jsx
+++ b/src/Components/Related/Related.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import { ContextObj } from '../../ContextObj.jsx';
 import Outfits from './Outfits';
 import ProductCard from './ProductCard';
+import Carousel from './Carousel';
 import './styles.css';
 import { getServer, grabReviewScore, formatDate } from '../../helpers';
 
@@ -9,12 +10,14 @@ const Related = (props) => {
 
   const { productId } = useContext(ContextObj);
   const [relatedItems, setRelatedItems] = useState([]);
+  const [isLoaded, setIsLoaded] = useState(true);
 
   useEffect(() => {
     if (productId) {
       getServer(`/products/${productId}/related`)
         .then( (result) => {
           setRelatedItems(result);
+          setIsLoaded(true);
         })
         .catch( (err) => {
           console.log('Related err:', err);
@@ -23,11 +26,16 @@ const Related = (props) => {
   }, [productId]);
 
   return (
-    <div className='relatedCarousel'>
-      {(relatedItems.length > 0) && relatedItems.map( (item, index) => {
-        return <ProductCard key={item} cardId={item}/>;
-      })}
-      <Outfits />
+    <div className='related'>
+      {isLoaded && <div>
+        <Carousel>
+          {(relatedItems.length > 0) && relatedItems.map( (item, index) => {
+            return <ProductCard key={item} cardId={item}/>;
+          })}
+        </Carousel>
+        <Outfits />
+      </div>}
+
     </div>
   );
 };

--- a/src/Components/Related/styles.css
+++ b/src/Components/Related/styles.css
@@ -14,11 +14,72 @@
   overflow: hidden;
 }
 
-.relatedCarousel {
-  height: 200px;
+.related {
+  max-width: 1200;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 64;
 }
 
 .outfits {
   clear: both;
-  height: 200px;
+  height: 225px;
+}
+
+/* CAROUSEL STYLES */
+
+.carousel-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.carousel-wrapper {
+  display: flex;
+  width: 100%;
+  position: relative;
+}
+
+.carousel-content-wrapper {
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+}
+
+.carousel-content {
+  display: flex;
+  transition: all 250ms linear;
+  -ms-overflow-style: none;  /* hide scrollbar in IE and Edge */
+  scrollbar-width: none;  /* hide scrollbar in Firefox */
+}
+
+/* hide scrollbar in webkit browser */
+.carousel-content::-webkit-scrollbar, .carousel-content::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel-content > * {
+  width: 100%;
+  flex-shrink: 0;
+  flex-grow: 1;
+}
+
+.left-arrow, .right-arrow {
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 48px;
+  height: 48px;
+  border-radius: 24px;
+  background-color: white;
+  border: 1px solid #ddd;
+}
+
+.left-arrow {
+  left: 24px;
+}
+
+.right-arrow {
+  right: 24px;
 }

--- a/src/Components/Related/styles.css
+++ b/src/Components/Related/styles.css
@@ -6,7 +6,9 @@
   border-width: thin;
   overflow: hidden;
 }
-
+.card-wrapper {
+  padding: 8;
+}
 .relatedPhoto {
   height: 150px;
   width: auto;
@@ -62,6 +64,18 @@
   width: 100%;
   flex-shrink: 0;
   flex-grow: 1;
+}
+
+.carousel-content.show-2 > * {
+  width: 50%;
+}
+
+.carousel-content.show-3 > * {
+  width: calc(100% / 3);
+}
+
+.carousel-content.show-4 > * {
+  width: 25%;
 }
 
 .left-arrow, .right-arrow {

--- a/src/Components/Related/styles.css
+++ b/src/Components/Related/styles.css
@@ -1,10 +1,17 @@
 .productCard {
-  height: 150px;
+  height: 225px;
+  width: 150px;
   float: left;
+  border-style: solid;
+  border-width: thin;
+  overflow: hidden;
 }
 
 .relatedPhoto {
-  height: 100px;
+  height: 150px;
+  width: auto;
+  object-fit: cover;
+  overflow: hidden;
 }
 
 .relatedCarousel {


### PR DESCRIPTION
Hey Team! I got carousel functionality working and a basis for my css. Also added functionality for when clicking on a related item, it changes the whole page to use that product Id. Note: You may see some errors in console if click items too fast due to the rate limiting. There are also some errors for things such as the selected item has no reviews or questions for each of those widgets that will need to be updated to accommodate. Also feel free to change the hardcoded default productId in App on line 11 to see what looks like with different lengths of related items, such as item 40350 has eight items.

https://trello.com/c/oDPvyfPO
https://trello.com/c/yFTHFolt